### PR TITLE
Go Parity

### DIFF
--- a/cobhan.go
+++ b/cobhan.go
@@ -47,6 +47,12 @@ func SetDefaultBufferMaximum(max int) {
 	DefaultBufferMaximum = max
 }
 
+func AllocateBuffer(length int) []byte {
+	buf := make([]byte, length+BUFFER_HEADER_SIZE)
+	updateBufferPtrLength(unsafe.Pointer(&buf[0]), length)
+	return buf
+}
+
 func bufferPtrToLength(bufferPtr unsafe.Pointer) C.int {
 	return C.int(*(*int32)(bufferPtr))
 }
@@ -85,13 +91,41 @@ func tempToBytes(ptr unsafe.Pointer, length C.int) ([]byte, int32) {
 }
 
 func Int64ToBuffer(value int64, dstPtr unsafe.Pointer) {
-    intPtr := (*int64)(dstPtr)
-    *intPtr = value
+	intPtr := (*int64)(dstPtr)
+	*intPtr = value
+}
+
+func Int64ToBufferSafe(value int64, dst *[]byte) {
+	Int64ToBuffer(value, unsafe.Pointer(&(*dst)[0]))
+}
+
+func BufferToInt64Safe(src *[]byte) int64 {
+	return BufferToInt64(unsafe.Pointer(&(*src)[0]))
+}
+
+func BufferToInt64(srcPtr unsafe.Pointer) int64 {
+	return *(*int64)(srcPtr)
 }
 
 func Int32ToBuffer(value int32, dstPtr unsafe.Pointer) {
-    intPtr := (*int32)(dstPtr)
-    *intPtr = value
+	intPtr := (*int32)(dstPtr)
+	*intPtr = value
+}
+
+func BufferToInt32Safe(src *[]byte) int32 {
+	return BufferToInt32(unsafe.Pointer(&(*src)[0]))
+}
+
+func BufferToInt32(srcPtr unsafe.Pointer) int32 {
+	return *(*int32)(srcPtr)
+}
+
+func Int32ToBufferSafe(value int32, dst *[]byte) {
+	Int32ToBuffer(value, unsafe.Pointer(&(*dst)[0]))
+}
+
+func BufferToBytesSafe(src *[]byte) ([]byte, int32) {
+	return BufferToBytes(unsafe.Pointer(&(*src)[0]))
 }
 
 func BufferToBytes(srcPtr unsafe.Pointer) ([]byte, int32) {
@@ -106,6 +140,10 @@ func BufferToBytes(srcPtr unsafe.Pointer) ([]byte, int32) {
 	} else {
 		return tempToBytes(srcPtr, length)
 	}
+}
+
+func BufferToStringSafe(src *[]byte) (string, int32) {
+	return BufferToString(unsafe.Pointer(&(*src)[0]))
 }
 
 func BufferToString(srcPtr unsafe.Pointer) (string, int32) {
@@ -126,6 +164,10 @@ func BufferToString(srcPtr unsafe.Pointer) (string, int32) {
 	}
 }
 
+func BufferToJsonSafe(src *[]byte) (map[string]interface{}, int32) {
+	return BufferToJson(unsafe.Pointer(&(*src)[0]))
+}
+
 func BufferToJson(srcPtr unsafe.Pointer) (map[string]interface{}, int32) {
 	bytes, result := BufferToBytes(srcPtr)
 	if result < 0 {
@@ -140,8 +182,16 @@ func BufferToJson(srcPtr unsafe.Pointer) (map[string]interface{}, int32) {
 	return loadedJson.(map[string]interface{}), ERR_NONE
 }
 
+func StringToBufferSafe(str string, dst *[]byte) int32 {
+	return StringToBuffer(str, unsafe.Pointer(&(*dst)[0]))
+}
+
 func StringToBuffer(str string, dstPtr unsafe.Pointer) int32 {
 	return BytesToBuffer([]byte(str), dstPtr)
+}
+
+func JsonToBufferSafe(v interface{}, dst *[]byte) int32 {
+	return JsonToBuffer(v, unsafe.Pointer(&(*dst)[0]))
 }
 
 func JsonToBuffer(v interface{}, dstPtr unsafe.Pointer) int32 {
@@ -150,6 +200,10 @@ func JsonToBuffer(v interface{}, dstPtr unsafe.Pointer) int32 {
 		return ERR_JSON_ENCODE_FAILED
 	}
 	return BytesToBuffer(outputBytes, dstPtr)
+}
+
+func BytesToBufferSafe(bytes []byte, dst *[]byte) int32 {
+	return BytesToBuffer(bytes, unsafe.Pointer(&(*dst)[0]))
 }
 
 func BytesToBuffer(bytes []byte, dstPtr unsafe.Pointer) int32 {

--- a/cobhan.go
+++ b/cobhan.go
@@ -90,38 +90,66 @@ func tempToBytes(ptr unsafe.Pointer, length C.int) ([]byte, int32) {
 	return fileData, ERR_NONE
 }
 
-func Int64ToBuffer(value int64, dstPtr unsafe.Pointer) {
+func Int64ToBuffer(value int64, dstPtr unsafe.Pointer) int32 {
+	if dstPtr == nil {
+		return ERR_NULL_PTR
+	}
 	intPtr := (*int64)(dstPtr)
 	*intPtr = value
+	return 0
 }
 
-func Int64ToBufferSafe(value int64, dst *[]byte) {
+func Int64ToBufferSafe(value int64, dst *[]byte) int32 {
+	if dst == nil {
+		return ERR_NULL_PTR
+	}
 	Int64ToBuffer(value, unsafe.Pointer(&(*dst)[0]))
+	return 0
 }
 
-func BufferToInt64Safe(src *[]byte) int64 {
+func BufferToInt64Safe(src *[]byte) (int64, int32) {
+	if src == nil {
+		return 0, ERR_NULL_PTR
+	}
 	return BufferToInt64(unsafe.Pointer(&(*src)[0]))
 }
 
-func BufferToInt64(srcPtr unsafe.Pointer) int64 {
-	return *(*int64)(srcPtr)
+func BufferToInt64(srcPtr unsafe.Pointer) (int64, int32) {
+	if srcPtr == nil {
+		return 0, ERR_NULL_PTR
+	}
+	return *(*int64)(srcPtr), 0
 }
 
-func Int32ToBuffer(value int32, dstPtr unsafe.Pointer) {
+func Int32ToBuffer(value int32, dstPtr unsafe.Pointer) int32 {
+	if dstPtr == nil {
+		return ERR_NULL_PTR
+	}
 	intPtr := (*int32)(dstPtr)
 	*intPtr = value
+	return 0
 }
 
-func BufferToInt32Safe(src *[]byte) int32 {
+func BufferToInt32Safe(src *[]byte) (int32, int32) {
+	if src == nil {
+		return 0, ERR_NULL_PTR
+	}
 	return BufferToInt32(unsafe.Pointer(&(*src)[0]))
 }
 
-func BufferToInt32(srcPtr unsafe.Pointer) int32 {
-	return *(*int32)(srcPtr)
+func BufferToInt32(srcPtr unsafe.Pointer) (int32, int32) {
+	if srcPtr == nil {
+		return 0, ERR_NULL_PTR
+	}
+	return *(*int32)(srcPtr), 0
 }
 
-func Int32ToBufferSafe(value int32, dst *[]byte) {
+func Int32ToBufferSafe(value int32, dst *[]byte) int32 {
+	if dst == nil {
+		return ERR_NULL_PTR
+	}
 	Int32ToBuffer(value, unsafe.Pointer(&(*dst)[0]))
+	return 0
 }
 
 func BufferToBytesSafe(src *[]byte) ([]byte, int32) {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+go test -v


### PR DESCRIPTION
- Introduce the missing AllocateBuffer method to enable Go as an FFI consumer
- Convert to unsafe.Pointer(&buf[0]) method to avoid cgo panic on Go pointers
- Introduce *Safe() methods for using managed buffers to enable Go as an FFI consumer
- Introduce tests and a GitHub action to run them