### PR TITLE
Delete temp files after reading them

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,5 @@
 root = true
 
-# Indentation
 [*]
 indent_style = tab
 indent_size = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+# Indentation
+[*]
+indent_style = tab
+indent_size = tab
+insert_final_newline = true
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true

--- a/cobhan.go
+++ b/cobhan.go
@@ -126,6 +126,9 @@ func tempToBytes(ptr unsafe.Pointer, length C.int) ([]byte, int32) {
 	if err != nil {
 		return nil, ERR_READ_TEMP_FILE_FAILED //TODO: Temp file read error
 	}
+
+  os.Remove(fileName) // Ignore delete error
+
 	return fileData, ERR_NONE
 }
 

--- a/cobhan.go
+++ b/cobhan.go
@@ -127,7 +127,7 @@ func tempToBytes(ptr unsafe.Pointer, length C.int) ([]byte, int32) {
 		return nil, ERR_READ_TEMP_FILE_FAILED //TODO: Temp file read error
 	}
 
-  os.Remove(fileName) // Ignore delete error
+	os.Remove(fileName) // Ignore delete error
 
 	return fileData, ERR_NONE
 }

--- a/cobhan_test.go
+++ b/cobhan_test.go
@@ -53,12 +53,12 @@ func TestStringRoundTripTemp(t *testing.T) {
 		t.Errorf("StringToBufferSafe returned %v", result)
 	}
 
-  // Capture the file name from the buffer
-  var fileNameLen int32
-  reader := bytes.NewReader(buf)
-  binary.Read(reader, binary.LittleEndian, &fileNameLen)
-  reader.Seek(int64(BUFFER_HEADER_SIZE), 0)
-  fileName := string(buf[BUFFER_HEADER_SIZE:BUFFER_HEADER_SIZE-fileNameLen])
+	// Capture the file name from the buffer
+	var fileNameLen int32
+	reader := bytes.NewReader(buf)
+	binary.Read(reader, binary.LittleEndian, &fileNameLen)
+	reader.Seek(int64(BUFFER_HEADER_SIZE), 0)
+	fileName := string(buf[BUFFER_HEADER_SIZE:BUFFER_HEADER_SIZE-fileNameLen])
 
 	output, result := BufferToStringSafe(&buf)
 	if result != 0 {

--- a/cobhan_test.go
+++ b/cobhan_test.go
@@ -68,9 +68,9 @@ func TestStringRoundTripTemp(t *testing.T) {
 		t.Errorf("Expected %v got %v", input, output)
 	}
 
-  if _, err := os.Stat(fileName); !errors.Is(err, os.ErrNotExist) {
-    t.Errorf("Temporary file %v was not deleted", fileName)
-  }
+	if _, err := os.Stat(fileName); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Temporary file %v was not deleted", fileName)
+	}
 }
 
 func TestStringRoundTripTempDoesNotFit(t *testing.T) {

--- a/cobhan_test.go
+++ b/cobhan_test.go
@@ -2,6 +2,9 @@ package cobhan
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 )
@@ -37,15 +40,25 @@ func TestStringRoundTrip(t *testing.T) {
 func TestStringRoundTripTemp(t *testing.T) {
 	// Make the string large enough to hold any rational temp file name
 	const stringSize = 16384
+
 	// Allocate a buffer too small for the input string
 	buf := AllocateBuffer(stringSize - 1)
+
 	// Allocate a string larger than the buffer so we use a temp file
 	input := strings.Repeat("X", stringSize)
+
 	// Should succeed because we can use a temp file and store the file name instead
 	result := StringToBufferSafe(input, &buf)
 	if result != ERR_NONE {
 		t.Errorf("StringToBufferSafe returned %v", result)
 	}
+
+  // Capture the file name from the buffer
+  var fileNameLen int32
+  reader := bytes.NewReader(buf)
+  binary.Read(reader, binary.LittleEndian, &fileNameLen)
+  reader.Seek(int64(BUFFER_HEADER_SIZE), 0)
+  fileName := string(buf[BUFFER_HEADER_SIZE:BUFFER_HEADER_SIZE-fileNameLen])
 
 	output, result := BufferToStringSafe(&buf)
 	if result != 0 {
@@ -54,6 +67,10 @@ func TestStringRoundTripTemp(t *testing.T) {
 	if output != input {
 		t.Errorf("Expected %v got %v", input, output)
 	}
+
+  if _, err := os.Stat(fileName); !errors.Is(err, os.ErrNotExist) {
+    t.Errorf("Temporary file %v was not deleted", fileName)
+  }
 }
 
 func TestStringRoundTripTempDoesNotFit(t *testing.T) {


### PR DESCRIPTION
So we don't fill up disk space when passing around large data at high volume, we should delete temp files after successfully reading them.