### PR TITLE
fix: avoid checkptr-invalid pointer arithmetic for zero-length buffers

### DIFF
--- a/cobhan.go
+++ b/cobhan.go
@@ -103,12 +103,28 @@ func bufferPtrToDataPtr(bufferPtr unsafe.Pointer) unsafe.Pointer {
 }
 
 func bufferPtrToString(bufferPtr unsafe.Pointer, length C.int) string {
+	// Computing a data pointer via uintptr(p)+offset past a zero-length
+	// (header-only) buffer is invalid pointer arithmetic under checkptr
+	// (go test -race), even though nothing would be read. Skip it entirely
+	// when there's nothing to read.
+	if length == 0 {
+		return ""
+	}
 	dataPtr := bufferPtrToDataPtr(bufferPtr)
 	//Allocation
 	return C.GoStringN((*C.char)(dataPtr), length)
 }
 
 func bufferPtrToBytes(bufferPtr unsafe.Pointer, length C.int) ([]byte, int32) {
+	// See bufferPtrToString: a zero-length buffer must not compute a data
+	// pointer via bufferPtrToDataPtr at all under checkptr.
+	if length == 0 {
+		if copyBuffers {
+			return []byte{}, ERR_NONE
+		}
+		return nil, ERR_NONE
+	}
+
 	src := unsafe.Slice((*byte)(bufferPtrToDataPtr(bufferPtr)), length)
 
 	if copyBuffers {
@@ -399,8 +415,19 @@ func BytesToBuffer(bytes []byte, dstPtr unsafe.Pointer) int32 {
 	dstCapInt := int(dstCap)
 	bytesLen := len(bytes)
 
-	// Construct a byte slice out of the unsafe pointers
-	var dst []byte = unsafe.Slice((*byte)(bufferPtrToDataPtr(dstPtr)), dstCapInt)
+	// Construct a byte slice out of the unsafe pointers. Only do this when
+	// there's an actual destination to write into: computing a pointer via
+	// uintptr(p)+offset past a zero-capacity (header-only) buffer -- even
+	// one that's never dereferenced -- is invalid pointer arithmetic that
+	// checkptr flags under `go test -race`. When dstCapInt is 0, dst stays
+	// nil; copy(nil, x) is always a valid no-op copying zero bytes, and the
+	// only way to reach the "else" branch below with dstCapInt == 0 is when
+	// bytesLen is also 0 (the dstCapInt < bytesLen branch is taken
+	// otherwise), so nothing is ever lost.
+	var dst []byte
+	if dstCapInt > 0 {
+		dst = unsafe.Slice((*byte)(bufferPtrToDataPtr(dstPtr)), dstCapInt)
+	}
 	var result int
 	if dstCapInt < bytesLen {
 		// Output will not fit in supplied buffer

--- a/cobhan_test.go
+++ b/cobhan_test.go
@@ -37,6 +37,27 @@ func TestStringRoundTrip(t *testing.T) {
 	}
 }
 
+// TestEmptyStringRoundTrip guards against a checkptr violation: allocating a
+// buffer for a zero-length string, then writing to and reading back from it,
+// computes a data pointer exactly one byte past the end of the (header-only)
+// allocation via bufferPtrToDataPtr's raw pointer arithmetic. That pointer is
+// never dereferenced for a zero-length value, but forming it via
+// uintptr(p)+offset (rather than Go's slice-indexing machinery) is exactly
+// what checkptr flags as invalid, crashing the whole process with "fatal
+// error: checkptr: pointer arithmetic result points to invalid allocation"
+// under `go test -race`. Run this test with -race to catch a regression.
+func TestEmptyStringRoundTrip(t *testing.T) {
+	input := ""
+	buf := testAllocateStringBuffer(t, input)
+	output, result := BufferToStringSafe(&buf)
+	if result != ERR_NONE {
+		t.Errorf("BufferToStringSafe returned %v", result)
+	}
+	if output != input {
+		t.Errorf("Expected %q got %q", input, output)
+	}
+}
+
 func TestStringRoundTripTemp(t *testing.T) {
 	// Make the string large enough to hold any rational temp file name
 	const stringSize = 16384
@@ -133,6 +154,21 @@ func TestBytesRoundTrip(t *testing.T) {
 
 	if !bytes.Equal(bytes1, bytes2) {
 		t.Error("Bytes don't match")
+	}
+}
+
+// TestEmptyBytesRoundTrip is the []byte counterpart of
+// TestEmptyStringRoundTrip -- see that test's comment for why a zero-length
+// buffer is a checkptr hazard under `go test -race`.
+func TestEmptyBytesRoundTrip(t *testing.T) {
+	bytes1 := []byte{}
+	buf := testAllocateBytesBuffer(t, bytes1)
+	bytes2, result := BufferToBytesSafe(&buf)
+	if result != ERR_NONE {
+		t.Errorf("BufferToBytesSafe returned %v", result)
+	}
+	if len(bytes2) != 0 {
+		t.Errorf("Expected empty result, got %v", bytes2)
 	}
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-go test -v -failfast -coverprofile cover.out
+go test -race -v -failfast -coverprofile cover.out


### PR DESCRIPTION
## Problem

Discovered while running `go test -race` on a downstream consumer (`gdcorp-uxp/switchboard-client`'s Go client): round-tripping an **empty** string or `[]byte` through `AllocateStringBuffer`/`AllocateBytesBuffer` + `BufferToStringSafe`/`BufferToBytesSafe` crashes the entire process:

```
fatal error: checkptr: pointer arithmetic result points to invalid allocation
...
github.com/godaddy/cobhan-go.bufferPtrToDataPtr(...)
	cobhan.go:102
github.com/godaddy/cobhan-go.BytesToBuffer(...)
	cobhan.go:403
```

`bufferPtrToDataPtr` computes `unsafe.Pointer(uintptr(bufferPtr) + BUFFER_HEADER_SIZE)`. For a zero-length value, `AllocateBuffer(0)` allocates exactly `BUFFER_HEADER_SIZE` (8) bytes -- header only, no data region -- so this arithmetic produces a pointer exactly one byte past the end of that allocation. That pointer is never dereferenced when the length is zero, but *forming* it via raw `uintptr` arithmetic (rather than Go's slice-indexing machinery, which is allowed to compute one-past-the-end addresses) is exactly what `checkptr` flags as invalid pointer arithmetic. This crashes under `go test -race` (and would also crash a production binary built with `-race`, or with `GODEBUG=checkptr=1` type instrumentation).

Three call sites are affected, all reachable from an empty input:
- `BytesToBuffer` (write path -- used by `AllocateStringBuffer("")`, `AllocateBytesBuffer([]byte{})`, `StringToBuffer`, `JsonToBuffer`)
- `bufferPtrToString` (read path -- `BufferToString` on a zero-length buffer)
- `bufferPtrToBytes` (read path -- `BufferToBytes` on a zero-length buffer)

## Test-driven fix

1. Added `TestEmptyStringRoundTrip` and `TestEmptyBytesRoundTrip` first, and confirmed both crash the test process under `go test -race` before touching `cobhan.go` (see commit history / can reproduce by checking out the test-only diff).
2. Fixed all three call sites to short-circuit on a zero length *before* calling `bufferPtrToDataPtr`, instead of computing-then-discarding the invalid pointer:
   - `BytesToBuffer`: `dst` stays `nil` when the destination capacity is 0; `copy(nil, bytes)` is always a valid no-op, and the only way to reach that branch with capacity 0 is when the input is also empty (a non-empty input with zero capacity takes the "doesn't fit, write to a temp file" branch instead, which never touches `dst` when the temp file name itself can't fit either -- unchanged behavior, just doesn't need the invalid pointer to get there).
   - `bufferPtrToString` / `bufferPtrToBytes`: return `""` / `nil` (or `[]byte{}` when `copyBuffers` is set, matching the existing non-empty behavior's allocation semantics) directly for `length == 0`.
3. Both new tests pass after the fix; full existing suite (18 tests) still passes under `-race`, no behavior change for non-empty buffers.
4. Added `-race` to `scripts/test.sh` so this class of regression is actually caught by CI going forward -- it wasn't before, which is how this went unnoticed.

## Testing

```
$ go test -race -run "TestEmptyStringRoundTrip|TestEmptyBytesRoundTrip" -v
=== RUN   TestEmptyStringRoundTrip
--- PASS: TestEmptyStringRoundTrip (0.00s)
=== RUN   TestEmptyBytesRoundTrip
--- PASS: TestEmptyBytesRoundTrip (0.00s)
PASS

$ ./scripts/test.sh   # full suite, now with -race
... (18 existing tests + 2 new, all pass)
PASS
coverage: 86.0% of statements
```