### PR TITLE
CI: test stable/oldstable Go matrix, bump actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,30 @@ jobs:
   test-linux:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [stable, oldstable]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version: ${{ matrix.go-version }}
         check-latest: 'true'
     - name: Test Cobhan
       run: scripts/test.sh
   test-macos:
     timeout-minutes: 15
     runs-on: 'macos-latest'
+    strategy:
+      matrix:
+        go-version: [stable, oldstable]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version: ${{ matrix.go-version }}
         check-latest: 'true'
     - name: Test Cobhan
       run: scripts/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         go-version: [stable, oldstable]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: 'true'
@@ -31,9 +31,9 @@ jobs:
       matrix:
         go-version: [stable, oldstable]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: 'true'


### PR DESCRIPTION
## Summary

Splits the CI workflow changes out of #19 into their own PR, so that PR can stay scoped purely to fuzz testing (and the bugs it found/fixed).

Two changes to `.github/workflows/test.yml`:

1. **Test against `stable` and `oldstable` Go on both OS jobs**, via a matrix, instead of a hardcoded `go-version: 1.24`. A pinned version silently drifts out of support; `stable`/`oldstable` keeps CI always covering the two currently-supported Go releases.
2. **Bump `actions/checkout` and `actions/setup-go` to v7** (from v4/v5).

## Testing

Workflow-only change; verified the resulting YAML is valid and identical to what was already exercised on #19's branch before this was split out.
