### PR TITLE
modernize cobhan.go: reduce duplication, use modern go idioms

### DIFF
--- a/cobhan.go
+++ b/cobhan.go
@@ -75,13 +75,7 @@ func AllocateBuffer(length int) []byte {
 }
 
 func AllocateStringBuffer(str string) ([]byte, int32) {
-	//Allocation
-	buf := AllocateBuffer(len(str))
-	result := StringToBufferSafe(str, &buf)
-	if result != ERR_NONE {
-		return nil, result
-	}
-	return buf, ERR_NONE
+	return AllocateBytesBuffer([]byte(str))
 }
 
 func AllocateBytesBuffer(bytes []byte) ([]byte, int32) {

--- a/cobhan.go
+++ b/cobhan.go
@@ -222,10 +222,7 @@ func IsBufferAllNulls(srcPtr unsafe.Pointer) bool {
 	if length <= 0 {
 		return false
 	}
-	checkLen := int(length)
-	if checkLen > 64 {
-		checkLen = 64
-	}
+	checkLen := min(int(length), 64)
 	src := unsafe.Slice((*byte)(bufferPtrToDataPtr(srcPtr)), checkLen)
 	for _, b := range src {
 		if b != 0 {

--- a/cobhan.go
+++ b/cobhan.go
@@ -93,7 +93,7 @@ func bufferPtrToLength(bufferPtr unsafe.Pointer) C.int {
 }
 
 func bufferPtrToDataPtr(bufferPtr unsafe.Pointer) unsafe.Pointer {
-	return unsafe.Pointer(uintptr(bufferPtr) + BUFFER_HEADER_SIZE)
+	return unsafe.Add(bufferPtr, BUFFER_HEADER_SIZE)
 }
 
 func bufferPtrToString(bufferPtr unsafe.Pointer, length C.int) string {
@@ -325,14 +325,14 @@ func BufferToString(srcPtr unsafe.Pointer) (string, int32) {
 	}
 }
 
-func BufferToJsonSafe(src *[]byte) (map[string]interface{}, int32) {
+func BufferToJsonSafe(src *[]byte) (map[string]any, int32) {
 	if src == nil {
 		return nil, ERR_NULL_PTR
 	}
 	return BufferToJson(Ptr(src))
 }
 
-func BufferToJson(srcPtr unsafe.Pointer) (map[string]interface{}, int32) {
+func BufferToJson(srcPtr unsafe.Pointer) (map[string]any, int32) {
 	if srcPtr == nil {
 		return nil, ERR_NULL_PTR
 	}
@@ -341,12 +341,12 @@ func BufferToJson(srcPtr unsafe.Pointer) (map[string]interface{}, int32) {
 		return nil, result
 	}
 
-	var loadedJson interface{}
+	var loadedJson any
 	err := json.Unmarshal(bytes, &loadedJson)
 	if err != nil {
 		return nil, ERR_JSON_DECODE_FAILED
 	}
-	jsonMap, ok := loadedJson.(map[string]interface{})
+	jsonMap, ok := loadedJson.(map[string]any)
 	if !ok {
 		// Valid JSON, but the top-level value isn't an object (e.g. an
 		// array, string, number, bool, or null).
@@ -355,7 +355,7 @@ func BufferToJson(srcPtr unsafe.Pointer) (map[string]interface{}, int32) {
 	return jsonMap, ERR_NONE
 }
 
-func BufferToJsonStruct(srcPtr unsafe.Pointer, dst interface{}) int32 {
+func BufferToJsonStruct(srcPtr unsafe.Pointer, dst any) int32 {
 	if srcPtr == nil {
 		return ERR_NULL_PTR
 	}
@@ -371,7 +371,7 @@ func BufferToJsonStruct(srcPtr unsafe.Pointer, dst interface{}) int32 {
 	return ERR_NONE
 }
 
-func BufferToJsonStructSafe(src *[]byte, dst interface{}) int32 {
+func BufferToJsonStructSafe(src *[]byte, dst any) int32 {
 	if src == nil {
 		return ERR_NULL_PTR
 	}
@@ -392,14 +392,14 @@ func StringToBuffer(str string, dstPtr unsafe.Pointer) int32 {
 	return BytesToBuffer([]byte(str), dstPtr)
 }
 
-func JsonToBufferSafe(v interface{}, dst *[]byte) int32 {
+func JsonToBufferSafe(v any, dst *[]byte) int32 {
 	if dst == nil {
 		return ERR_NULL_PTR
 	}
 	return JsonToBuffer(v, Ptr(dst))
 }
 
-func JsonToBuffer(v interface{}, dstPtr unsafe.Pointer) int32 {
+func JsonToBuffer(v any, dstPtr unsafe.Pointer) int32 {
 	if dstPtr == nil {
 		return ERR_NULL_PTR
 	}

--- a/cobhan.go
+++ b/cobhan.go
@@ -153,8 +153,7 @@ func Int64ToBufferSafe(value int64, dst *[]byte) int32 {
 	if dst == nil {
 		return ERR_NULL_PTR
 	}
-	Int64ToBuffer(value, Ptr(dst))
-	return 0
+	return Int64ToBuffer(value, Ptr(dst))
 }
 
 func BufferToInt64Safe(src *[]byte) (int64, int32) {
@@ -198,8 +197,7 @@ func Int32ToBufferSafe(value int32, dst *[]byte) int32 {
 	if dst == nil {
 		return ERR_NULL_PTR
 	}
-	Int32ToBuffer(value, Ptr(dst))
-	return 0
+	return Int32ToBuffer(value, Ptr(dst))
 }
 
 func BufferLength(srcPtr unsafe.Pointer) int32 {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/godaddy/cobhan-go
 
-go 1.18
+go 1.21


### PR DESCRIPTION
## Summary

Addresses all three findings from #20 (an over-engineering/duplication-only audit; no correctness or security claims involved), plus a couple of additional modern-Go idiom cleanups found while looking at the same code. Each fix is behavior-preserving and covered by the existing test suite -- no new tests needed.

## 1. `AllocateStringBuffer` delegates to `AllocateBytesBuffer`

Was duplicating the exact same alloc/convert/check body. `StringToBuffer` already just does `BytesToBuffer([]byte(str), dstPtr)` under the hood, so:

```go
func AllocateStringBuffer(str string) ([]byte, int32) {
	return AllocateBytesBuffer([]byte(str))
}
```

Covered by `TestStringRoundTrip`, `TestStringRoundTripTemp`, `TestStringRoundTripTempDoesNotFit`, `TestJson`.

## 2. `Int64ToBufferSafe`/`Int32ToBufferSafe` return the underlying call's result

Both previously called the raw setter, discarded its return value, and hardcoded `0`. Harmless today (`dst` is already confirmed non-nil, so the raw call can't fail here), but a latent footgun if either raw function ever grows another failure path. Now:

```go
func Int64ToBufferSafe(value int64, dst *[]byte) int32 {
	if dst == nil {
		return ERR_NULL_PTR
	}
	return Int64ToBuffer(value, Ptr(dst))
}
```

Covered by `TestInt64RoundTrip`, `TestInt32RoundTrip`, `TestNullChecks`.

## 3. `IsBufferAllNulls` uses the `min` builtin instead of a hand-rolled clamp

```go
checkLen := min(int(length), 64)
```

This one has a real tradeoff, called out explicitly in #20: `min`/`max` builtins need Go 1.21+, so `go.mod`'s declared minimum is bumped from `1.18` to `1.21`. CI (see #21) only tests `stable`/`oldstable` Go, both well past 1.21, so this floor isn't expected to bind for any currently-supported toolchain -- but it is a real, if small, compatibility decision for any consumer still pinned below 1.21, called out here rather than silently bundled.

Covered by `TestIsBufferAllNulls`.

## 4. `interface{}` -> `any`

Straight syntax modernization (alias since Go 1.18) across the JSON-facing API (`BufferToJson`, `BufferToJsonStruct`, `JsonToBuffer`, and their `Safe` wrappers). No behavior change, no go.mod bump needed.

## 5. `bufferPtrToDataPtr` uses `unsafe.Add` instead of manual `uintptr` arithmetic

```go
func bufferPtrToDataPtr(bufferPtr unsafe.Pointer) unsafe.Pointer {
	return unsafe.Add(bufferPtr, BUFFER_HEADER_SIZE)
}
```

Same generated arithmetic, but this is the idiomatic Go 1.17+ way to express pointer+offset and is clearer than casting through `uintptr`. The zero-length/checkptr edge cases this function's callers guard against are unaffected -- they still short-circuit before this function is ever called with a header-only buffer.

Ran `gofmt -s`, `go vet`, and `staticcheck` over the package -- no other findings.

## Testing
```
$ scripts/test.sh
...
PASS
coverage: 89.4% of statements
ok  	github.com/godaddy/cobhan-go	1.4s
```

Closes #20.